### PR TITLE
refactor:#29 create부분 리팩토링

### DIFF
--- a/src/main/java/com/back/cafe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/back/cafe/domain/product/controller/ProductController.java
@@ -1,7 +1,8 @@
 package com.back.cafe.domain.product.controller;
 
 import com.back.cafe.domain.product.dto.ProductDto;
-import com.back.cafe.domain.product.dto.ProductModifyRequest;
+import com.back.cafe.domain.product.dto.ProductRequestDto.ProductCreateRequest;
+import com.back.cafe.domain.product.dto.ProductRequestDto.ProductModifyRequest;
 import com.back.cafe.domain.product.service.ProductService;
 import com.back.cafe.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,29 +45,13 @@ public class ProductController {
         return productService.findById(id);
     }
 
-    record ProductCreateReq(
-            @NotBlank String name,
-            @NotBlank String category,
-            @NotNull Long price,
-            @NotNull Integer stock,
-            @NotBlank String description,
-            @NotBlank String imageUrl
-    ) {
-    }
 
     @PostMapping
     @Operation(summary = "신규 상품 생성", description = "관리자가 상품을 신규 추가 합니다.")
     public RsData<ProductDto> createProduct(
-            @RequestBody @Valid ProductCreateReq req
+            @RequestBody @Valid ProductCreateRequest req
     ) {
-        ProductDto productDto = productService.create(
-                req.name(),
-                req.category(),
-                req.price(),
-                req.stock(),
-                req.description(),
-                req.imageUrl()
-        );
+        ProductDto productDto = productService.create(req.toServiceDto());
 
         return new RsData<>(
                 "%d번 상품이 생성되었습니다".formatted(productDto.id()),

--- a/src/main/java/com/back/cafe/domain/product/dto/ProductRequestDto/ProductCreateRequest.java
+++ b/src/main/java/com/back/cafe/domain/product/dto/ProductRequestDto/ProductCreateRequest.java
@@ -1,9 +1,12 @@
-package com.back.cafe.domain.product.dto;
+package com.back.cafe.domain.product.dto.ProductRequestDto;
 
+import jakarta.validation.constraints.NotBlank;
+
+import com.back.cafe.domain.product.dto.ServiceDto.ServiceCreateProductDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record ProductModifyRequest(
+public record ProductCreateRequest(
         @NotBlank String name,
         @NotBlank String category,
         @NotNull Long price,
@@ -11,8 +14,8 @@ public record ProductModifyRequest(
         @NotBlank String description,
         @NotBlank String imageUrl
 ) {
-    public ServiceModifyProductDto toServiceDto(){
-        return new ServiceModifyProductDto(
+    public ServiceCreateProductDto toServiceDto(){
+        return new ServiceCreateProductDto(
                 name,
                 category,
                 price,
@@ -21,6 +24,4 @@ public record ProductModifyRequest(
                 imageUrl
         );
     }
-
 }
-

--- a/src/main/java/com/back/cafe/domain/product/dto/ProductRequestDto/ProductModifyRequest.java
+++ b/src/main/java/com/back/cafe/domain/product/dto/ProductRequestDto/ProductModifyRequest.java
@@ -1,0 +1,27 @@
+package com.back.cafe.domain.product.dto.ProductRequestDto;
+
+import com.back.cafe.domain.product.dto.ServiceDto.ServiceModifyProductDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductModifyRequest(
+        @NotBlank String name,
+        @NotBlank String category,
+        @NotNull Long price,
+        @NotNull Integer stock,
+        @NotBlank String description,
+        @NotBlank String imageUrl
+) {
+    public ServiceModifyProductDto toServiceDto(){
+        return new ServiceModifyProductDto(
+                name,
+                category,
+                price,
+                stock,
+                description,
+                imageUrl
+        );
+    }
+
+}
+

--- a/src/main/java/com/back/cafe/domain/product/dto/ServiceDto/ServiceCreateProductDto.java
+++ b/src/main/java/com/back/cafe/domain/product/dto/ServiceDto/ServiceCreateProductDto.java
@@ -1,0 +1,14 @@
+package com.back.cafe.domain.product.dto.ServiceDto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ServiceCreateProductDto(
+        @NotBlank String name,
+        @NotBlank String category,
+        @NotNull Long price,
+        @NotNull Integer stock,
+        @NotBlank String description,
+        @NotBlank String imageUrl
+) {
+}

--- a/src/main/java/com/back/cafe/domain/product/dto/ServiceDto/ServiceModifyProductDto.java
+++ b/src/main/java/com/back/cafe/domain/product/dto/ServiceDto/ServiceModifyProductDto.java
@@ -1,4 +1,4 @@
-package com.back.cafe.domain.product.dto;
+package com.back.cafe.domain.product.dto.ServiceDto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/back/cafe/domain/product/service/ProductService.java
+++ b/src/main/java/com/back/cafe/domain/product/service/ProductService.java
@@ -3,18 +3,17 @@ package com.back.cafe.domain.product.service;
 import com.back.cafe.domain.order.dto.OrderProductDto;
 import com.back.cafe.domain.order.entity.OrderProduct;
 import com.back.cafe.domain.product.dto.ProductDto;
-import com.back.cafe.domain.product.dto.ServiceModifyProductDto;
+import com.back.cafe.domain.product.dto.ServiceDto.ServiceCreateProductDto;
+import com.back.cafe.domain.product.dto.ServiceDto.ServiceModifyProductDto;
 import com.back.cafe.domain.product.entity.Product;
 import com.back.cafe.domain.product.repository.ProductRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,8 +35,15 @@ public class ProductService {
     }
 
     @Transactional
-    public ProductDto create(String name, String category, Long price, int stock, String description, String imageUrl){
-        Product product = new Product(name,category,price,stock,description,imageUrl);
+    public ProductDto create(ServiceCreateProductDto serviceCreateProductDto){
+        Product product = new Product(
+                serviceCreateProductDto.name(),
+                serviceCreateProductDto.category(),
+                serviceCreateProductDto.price(),
+                serviceCreateProductDto.stock(),
+                serviceCreateProductDto.description(),
+                serviceCreateProductDto.imageUrl()
+        );
         return ProductDto.from(productRepository.save(product));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#29

## 📝작업 내용

Create 관련해서, CreateReq 와 서비스로 넘겨줄때 서비스 전용, Dto 제작하였습니다.
리팩토링후 전과 같이 동작하는 것을 확인하였습니다

## ✅ 주요 변경 사항
컨트롤러에서 요청 값을 개별 파라미터로 넘기던 방식을 제거

CreateRequestBody → 서비스 전용 DTO로 변환하는 구조로 변경

서비스 계층이 컨트롤러의 요청 객체에 직접 의존하지 않도록 개선
## 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)

이번 변경으로 서비스가 컨트롤러 요청 객체에 의존하지 않게 되었다는 장점이 있다고 생각했습니다.

다만 DTO 패키지 내에 요청/응답/서비스 전용 DTO가 점점 많아질 수 있는데,
이 경우 패키지 구조나 클래스 관리 측면에서 어떤 방식으로 정리해두는 것이 좋을지 의견 부탁드립니다.